### PR TITLE
Add Curseforge Meta file

### DIFF
--- a/pkgmeta.yaml
+++ b/pkgmeta.yaml
@@ -1,0 +1,9 @@
+package-as: Gratwurst
+enable-nolib-creation: no
+
+ignore: # Files and directories beginning with a dot (such as .git) are automatically ignored, as is the pgkmeta file itself.
+    - media
+    - backupAndCopyAddon.ps1
+    - README.md
+
+license-output: LICENSE.txt


### PR DESCRIPTION
Add curseforge meta file since it isn't smart enough to grab the release artifact.

[docs on curseforge](https://authors.curseforge.com/knowledge-base/projects/3451-automatic-packaging)