### PR TITLE
Bug/self congrats 2.0

### DIFF
--- a/Gratwurst.lua
+++ b/Gratwurst.lua
@@ -14,11 +14,11 @@ function InitializeAddon(self)
 	end
 
 	if (GratwurstUnitName == nil) then
-		GratwurstUnitName = strjoin("-", UnitName("player"), GetRealmName())
+		GratwurstUnitName = strjoin("-", UnitName("player"), strjoin("", strsplit(" ", GetRealmName())))
 	end;
 
 	SetConfigurationWindow();
-end
+end 
 
 function SetConfigurationWindow()
 	local luaFrame = CreateFrame("Frame", "GratwurstPanel", InterfaceOptionsFramePanelContainer)

--- a/Gratwurst.lua
+++ b/Gratwurst.lua
@@ -1,5 +1,6 @@
 function InitializeAddon(self)
 	self:RegisterEvent("CHAT_MSG_GUILD_ACHIEVEMENT")
+	self:RegisterEvent("PLAYER_LOGIN")
 	
     if(GratwurstMessage == nil)then
 		GratwurstMessage="";
@@ -12,11 +13,7 @@ function InitializeAddon(self)
 	if(GratwurstEnabled == nil) then
 		GratwurstEnabled = true;
 	end
-
-	if (GratwurstUnitName == nil) then
-		GratwurstUnitName = strjoin("-", UnitName("player"), strjoin("", strsplit(" ", GetRealmName())))
-	end;
-
+	
 	SetConfigurationWindow();
 end 
 
@@ -142,7 +139,11 @@ function SetConfigurationWindow()
 end
 
 function OnEventRecieved(self, event, msg, author, ...)
-	if (event == "CHAT_MSG_GUILD_ACHIEVEMENT") then 
+	if (event == "PLAYER_LOGIN") then
+		if (GratwurstUnitName == nil or strfind(GratwurstUnitName, " ")) then
+			GratwurstUnitName = strjoin("-", UnitName("player"), GetNormalizedRealmName())
+		end;
+	elseif (event == "CHAT_MSG_GUILD_ACHIEVEMENT") then 
 		if (author ~= GratwurstUnitName) then
 			GuildAchievementMessageEventRecieved();
 		end

--- a/updates.txt
+++ b/updates.txt
@@ -1,3 +1,6 @@
+1.2.9 - Fixed an issue where users of an early version may have had unit 
+        names with whitespace stored, allowing for self congratulations to
+        persist.
 1.2.8 - Fixed issue where players on realms with whitespace in the name would
         congratulate themselves.  No room for that sort of egotism here.
 1.2.6 - Add "/gw c" command to open configuration window. Official changelog.


### PR DESCRIPTION
I'm a dummy.  Apparently we were storing the unit name, with realm, as a saved variable, and it was never being overwritten.  If the player had a space in their realm name, it was there.  

Then it turns out, that the GetNormalizedRealmName returns nil if it loads too fast, so had to trigger off the PLAYER_LOGIN event.

