### PR TITLE
9.2 Support and Force Random Delay (hooomanistic?)

### DIFF
--- a/Gratwurst.lua
+++ b/Gratwurst.lua
@@ -5,18 +5,21 @@ function InitializeAddon(self)
     if(GratwurstMessage == nil)then
 		GratwurstMessage="";
 	end
-
+	
 	if(GratwurstDelayInSeconds == nil)then
 		GratwurstDelayInSeconds = 3;
+	end
+
+	if(GratwurstRandomDelayMax == nil)then
+		-- Updating from old value to new one
+		GratwurstRandomDelayMax = GratwurstDelayInSeconds;
 	end
 
 	if(GratwurstEnabled == nil) then
 		GratwurstEnabled = true;
 	end
 
-	if(GratwurstRandomTTTEnabled == nil) then
-		GratwurstRandomTTTEnabled = true;
-	end
+	GratwurstRandomDelayEnabled = true;
 	
 	SetConfigurationWindow();
 end 
@@ -46,88 +49,112 @@ function SetConfigurationWindow()
 	Gratwurst.ui.panel.name = "Gratwurst";
 
 	-- Control - IsEnabled CheckBox
-	local isEnabledCheckButton = CreateFrame("CheckButton", "IsEnabledCheckButton", Gratwurst.ui.panel, "ChatConfigCheckButtonTemplate");
-	isEnabledCheckButton:SetPoint("TOPLEFT", 20, -50);
-	isEnabledCheckButton:SetScript("OnShow",
-		function(self, event, arg1)
-			self:SetChecked(GratwurstEnabled);
-		end);
-	isEnabledCheckButton:SetScript("OnClick",
-		function()
-			if (GratwurstEnabled) then
-				GratwurstEnabled = false;
-			else
-				GratwurstEnabled = true;
-			end
-		end);
+	-- local isEnabledCheckButton = CreateFrame("CheckButton", "IsEnabledCheckButton", Gratwurst.ui.panel, "ChatConfigCheckButtonTemplate");
+	-- isEnabledCheckButton:SetPoint("TOPLEFT", 20, -50);
+	-- isEnabledCheckButton:SetScript("OnShow",
+	-- 	function(self, event, arg1)
+	-- 		self:SetChecked(GratwurstEnabled);
+	-- 	end);
+	-- isEnabledCheckButton:SetScript("OnClick",
+	-- 	function()
+	-- 		if (GratwurstEnabled) then
+	-- 			GratwurstEnabled = false;
+	-- 		else
+	-- 			GratwurstEnabled = true;
+	-- 		end
+	-- 	end);
 		
-	local isEnabledCheckButtonLabel = isEnabledCheckButton:CreateFontString("isEnabledCheckButtonLabel")
-	isEnabledCheckButtonLabel:SetFont("Fonts\\FRIZQT__.TTF", 12)
-	isEnabledCheckButtonLabel:SetWidth(120)
-	isEnabledCheckButtonLabel:SetHeight(20)
-	isEnabledCheckButtonLabel:SetPoint("TOPLEFT", -31, 15)
-	isEnabledCheckButtonLabel:SetTextColor(1, 0.8196079, 0)
-	isEnabledCheckButtonLabel:SetShadowOffset(1, -1)
-	isEnabledCheckButtonLabel:SetShadowColor(0, 0, 0)
-	isEnabledCheckButtonLabel:SetText("Enabled")
+	-- local isEnabledCheckButtonLabel = isEnabledCheckButton:CreateFontString("isEnabledCheckButtonLabel")
+	-- isEnabledCheckButtonLabel:SetFont("Fonts\\FRIZQT__.TTF", 12)
+	-- isEnabledCheckButtonLabel:SetWidth(120)
+	-- isEnabledCheckButtonLabel:SetHeight(20)
+	-- isEnabledCheckButtonLabel:SetPoint("TOPLEFT", -31, 15)
+	-- isEnabledCheckButtonLabel:SetTextColor(1, 0.8196079, 0)
+	-- isEnabledCheckButtonLabel:SetShadowOffset(1, -1)
+	-- isEnabledCheckButtonLabel:SetShadowColor(0, 0, 0)
+	-- isEnabledCheckButtonLabel:SetText("Enabled")
 
 	-- Control - Randomize Time To Talk CheckBox
-	local isRandomTTTCheckButton = CreateFrame("CheckButton", "IsRandomTTTCheckButton", Gratwurst.ui.panel, "ChatConfigCheckButtonTemplate");
-	isRandomTTTCheckButton:SetPoint("TOPLEFT", 20, -100);
-	isRandomTTTCheckButton:SetScript("OnShow",
-		function(self, event, arg1)
-			self:SetChecked(GratwurstRandomTTTEnabled);
-		end);
-	isRandomTTTCheckButton:SetScript("OnClick",
-		function()
-			if (GratwurstRandomTTTEnabled) then
-				GratwurstRandomTTTEnabled = false;
-			else
-				GratwurstRandomTTTEnabled = true;
-			end
-		end);
+	-- local isRandomTTTCheckButton = CreateFrame("CheckButton", "IsRandomTTTCheckButton", Gratwurst.ui.panel, "ChatConfigCheckButtonTemplate");
+	-- isRandomTTTCheckButton:SetPoint("TOPLEFT", 20, -100);
+	-- isRandomTTTCheckButton:SetScript("OnShow",
+	-- 	function(self, event, arg1)
+	-- 		self:SetChecked(GratwurstRandomDelayEnabled);
+	-- 	end);
+	-- isRandomTTTCheckButton:SetScript("OnClick",
+	-- 	function()
+	-- 		if (GratwurstRandomDelayEnabled) then
+	-- 			GratwurstRandomDelayEnabled = false;
+	-- 		else
+	-- 			GratwurstRandomDelayEnabled = true;
+	-- 		end
+	-- 	end);
 		
-	local isRandomTTTCheckButtonLabel = isRandomTTTCheckButton:CreateFontString("isRandomTTTCheckButtonLabel")
-	isRandomTTTCheckButtonLabel:SetFont("Fonts\\FRIZQT__.TTF", 12)
-	isRandomTTTCheckButtonLabel:SetWidth(120)
-	isRandomTTTCheckButtonLabel:SetHeight(20)
-	isRandomTTTCheckButtonLabel:SetPoint("TOPLEFT", -31, 15)
-	isRandomTTTCheckButtonLabel:SetTextColor(1, 0.8196079, 0)
-	isRandomTTTCheckButtonLabel:SetShadowOffset(1, -1)
-	isRandomTTTCheckButtonLabel:SetShadowColor(0, 0, 0)
-	isRandomTTTCheckButtonLabel:SetText("Random Delay")
+	-- local isRandomTTTCheckButtonLabel = isRandomTTTCheckButton:CreateFontString("isRandomTTTCheckButtonLabel")
+	-- isRandomTTTCheckButtonLabel:SetFont("Fonts\\FRIZQT__.TTF", 12)
+	-- isRandomTTTCheckButtonLabel:SetWidth(120)
+	-- isRandomTTTCheckButtonLabel:SetHeight(20)
+	-- isRandomTTTCheckButtonLabel:SetPoint("TOPLEFT", -31, 15)
+	-- isRandomTTTCheckButtonLabel:SetTextColor(1, 0.8196079, 0)
+	-- isRandomTTTCheckButtonLabel:SetShadowOffset(1, -1)
+	-- isRandomTTTCheckButtonLabel:SetShadowColor(0, 0, 0)
+	-- isRandomTTTCheckButtonLabel:SetText("Random Delay")
+
+	-- Slider - Gratwurst Max Delay Slider
+	-- local MySlider = CreateFrame("Slider", "GratwurstMaxDelaySlider", Gratwurst.ui.panel, "OptionsSliderTemplate")
+	-- MySlider:SetWidth(20)
+	-- MySlider:SetHeight(100)
+	-- MySlider:SetOrientation('HORIZONTAL')
+
 
 	-- Control - GratwurstDelayInSeconds
-	local delayEditBox = CreateFrame("EditBox", "Input_GratwurstDelayInSeconds", Gratwurst.ui.panel, "InputBoxTemplate")
-	delayEditBox:SetSize(25,30)
-	delayEditBox:SetMultiLine(false)
-    delayEditBox:ClearAllPoints()
-	delayEditBox:SetPoint("TOPLEFT", 25, -150)
-	delayEditBox:SetCursorPosition(0);
-	delayEditBox:ClearFocus();
-    delayEditBox:SetAutoFocus(false)
-	delayEditBox:SetScript("OnShow", function(self,event,arg1)
-		self:SetNumber(GratwurstDelayInSeconds)
+	-- local delayEditBox = CreateFrame("EditBox", "Input_GratwurstDelayInSeconds", Gratwurst.ui.panel, "InputBoxTemplate")
+	-- delayEditBox:SetSize(25,30)
+	-- delayEditBox:SetMultiLine(false)
+    -- delayEditBox:ClearAllPoints()
+	-- delayEditBox:SetPoint("TOPLEFT", 25, -150)
+	-- delayEditBox:SetCursorPosition(0);
+	-- delayEditBox:ClearFocus();
+    -- delayEditBox:SetAutoFocus(false)
+	-- delayEditBox:SetScript("OnShow", function(self,event,arg1)
+	-- 	self:SetNumber(GratwurstDelayInSeconds)
+	-- 	self:SetCursorPosition(0);
+	-- 	self:ClearFocus();
+	-- end)
+	-- delayEditBox:SetScript("OnTextChanged", function(self,value)
+	-- 	GratwurstDelayInSeconds = self:GetNumber()
+	-- end)
+
+	local maxDelayEditBox = CreateFrame("EditBox", "Input_GratwurstRandomDelayMax", Gratwurst.ui.panel, "InputBoxTemplate")
+	maxDelayEditBox:SetSize(25,30)
+	maxDelayEditBox:SetMultiLine(false)
+    maxDelayEditBox:ClearAllPoints()
+	maxDelayEditBox:SetPoint("TOPLEFT", 34, -50)
+	maxDelayEditBox:SetCursorPosition(0);
+	maxDelayEditBox:ClearFocus();
+    maxDelayEditBox:SetAutoFocus(false)
+	maxDelayEditBox:SetScript("OnShow", function(self,event,arg1)
+		self:SetNumber(GratwurstRandomDelayMax)
 		self:SetCursorPosition(0);
 		self:ClearFocus();
 	end)
-	delayEditBox:SetScript("OnTextChanged", function(self,value)
-		GratwurstDelayInSeconds = self:GetNumber()
+	maxDelayEditBox:SetScript("OnTextChanged", function(self,value)
+		GratwurstRandomDelayMax = self:GetNumber()
 	end)
 	
-	local delayEditBoxLabel = delayEditBox:CreateFontString("delayEditBoxLabel")
-	delayEditBoxLabel:SetFont("Fonts\\FRIZQT__.TTF", 12)
-	delayEditBoxLabel:SetWidth(120)
-	delayEditBoxLabel:SetHeight(20)
-	delayEditBoxLabel:SetPoint("TOPLEFT", -10, 15)
-	delayEditBoxLabel:SetTextColor(1, 0.8196079, 0)
-	delayEditBoxLabel:SetShadowOffset(1, -1)
-	delayEditBoxLabel:SetShadowColor(0, 0, 0)
-	delayEditBoxLabel:SetText("Delay in seconds")
+	local maxDelayEditBoxLabel = maxDelayEditBox:CreateFontString("maxDelayEditBoxLabel")
+	maxDelayEditBoxLabel:SetFont("Fonts\\FRIZQT__.TTF", 12)
+	maxDelayEditBoxLabel:SetWidth(250)
+	maxDelayEditBoxLabel:SetHeight(20)
+	maxDelayEditBoxLabel:SetPoint("TOPLEFT", -6, -6)
+	maxDelayEditBoxLabel:SetTextColor(1, 0.8196079, 0)
+	maxDelayEditBoxLabel:SetShadowOffset(1, -1)
+	maxDelayEditBoxLabel:SetShadowColor(0, 0, 0)
+	maxDelayEditBoxLabel:SetText("Max Delay (up to 9 seconds)")
 
 
 	local backdropFrame = CreateFrame("Frame", nil, Gratwurst.ui.panel, BackdropTemplateMixin and "BackdropTemplate")
-	backdropFrame:SetPoint("TOPLEFT", 20,-200)
+	backdropFrame:SetPoint("TOPLEFT", 25,-110)
 	backdropFrame:SetSize(335, 215)
 	backdropFrame:SetBackdrop( {
 		bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
@@ -158,13 +185,13 @@ function SetConfigurationWindow()
 
 	local editBoxLabel = backdropFrame:CreateFontString("editBoxLabel")
 	editBoxLabel:SetFont("Fonts\\FRIZQT__.TTF", 12)
-	editBoxLabel:SetWidth(120)
+	editBoxLabel:SetWidth(250)
 	editBoxLabel:SetHeight(20)
-	editBoxLabel:SetPoint("TOPLEFT", -17 ,20)
+	editBoxLabel:SetPoint("TOPLEFT", -20 ,20)
 	editBoxLabel:SetTextColor(1, 0.8196079, 0)
 	editBoxLabel:SetShadowOffset(1, -1)
 	editBoxLabel:SetShadowColor(0, 0, 0)
-	editBoxLabel:SetText("Message list")
+	editBoxLabel:SetText("Gratz List (one message per line)")
 
 	InterfaceOptions_AddCategory(Gratwurst.ui.panel);	
 end
@@ -183,8 +210,15 @@ end
 
 function GuildAchievementMessageEventRecieved()
 	gratsStop=true
-	if GratwurstRandomTTTEnabled then
-		GratwurstDelayInSeconds = math.random(1,4)
+	if GratwurstRandomDelayEnabled then
+		-- TODO: Make a slider for this instead of checking
+		if GratwurstRandomDelayMax < 1 then
+			GratwurstRandomDelayMax = 1
+		end
+		if GratwurstRandomDelayMax > 9 then
+			GratwurstRandomDelayMax = 9
+		end
+		GratwurstDelayInSeconds = math.random(1,GratwurstRandomDelayMax)
 	end
     C_Timer.After(GratwurstDelayInSeconds,function()
         if gratsStop and GratwurstEnabled and GratwurstMessage ~= "" then

--- a/Gratwurst.toc
+++ b/Gratwurst.toc
@@ -1,9 +1,9 @@
 ## Author: Bitobrian, Galiagante 
-## Interface: 90105
+## Interface: 90200
 ## Notes: Automatically send congrats for achievements in chat.
 ## Title: Gratwurst
 ## Version: 1.0.1
 ## DefaultState: Enabled
-## SavedVariablesPerCharacter: GratwurstMessage, GratwurstDelayInSeconds, GratwurstEnabled, GratwurstUnitName, GratwurstRandomTTTEnabled
+## SavedVariablesPerCharacter: GratwurstMessage, GratwurstDelayInSeconds, GratwurstEnabled, GratwurstUnitName, GratwurstRandomDelayEnabled, GratwurstRandomDelayMax
 Gratwurst.lua
 Gratwurst.xml


### PR DESCRIPTION
- Update delay to be maximum random delay. It will always have a max range of 1 to 9 seconds. You can define the maximum amount of delay, but it will always randomize per event.
- Add new variable with init to take old value variable on first run when var is not stored. Soft deleted old code. 
- Update to 9.2.