### PR TITLE
feat: improve /gw debug output to print full addon state

### DIFF
--- a/Gratwurst.lua
+++ b/Gratwurst.lua
@@ -1235,9 +1235,10 @@ local function slashcmd(msg, editbox)
 			DEFAULT_CHAT_FRAME:AddMessage("|cffffedbaGratwurst:|r Status: Disabled\n")
 		end
 		DEFAULT_CHAT_FRAME:AddMessage("|cffffedbaGratwurst:|r Slash commands:")
-		DEFAULT_CHAT_FRAME:AddMessage("|cffffedbaGratwurst:|r   /gw c   -> Open Configuration")
-		DEFAULT_CHAT_FRAME:AddMessage("|cffffedbaGratwurst:|r   /gw enable   -> Enable Gratwurst")
-		DEFAULT_CHAT_FRAME:AddMessage("|cffffedbaGratwurst:|r   /gw disable  -> Disable Gratwurst")
+		DEFAULT_CHAT_FRAME:AddMessage("|cffffedbaGratwurst:|r   /gw c       -> Open Configuration")
+		DEFAULT_CHAT_FRAME:AddMessage("|cffffedbaGratwurst:|r   /gw enable  -> Enable Gratwurst")
+		DEFAULT_CHAT_FRAME:AddMessage("|cffffedbaGratwurst:|r   /gw disable -> Disable Gratwurst")
+		DEFAULT_CHAT_FRAME:AddMessage("|cffffedbaGratwurst:|r   /gw debug   -> Print state and simulate a grats")
 	elseif (msg == "c") then
 		Settings.OpenToCategory(category.ID, "Gratwurst")
 	elseif (msg == "enable") then
@@ -1249,11 +1250,13 @@ local function slashcmd(msg, editbox)
 	elseif (msg == "debug") then
 		-- output saved variables to chat
 		print("=======================")
-		print("GratwurstDelayInSeconds: " .. GratwurstDelayInSeconds)
-		print("GratwurstRandomDelayMax: " .. GratwurstRandomDelayMax)
 		print("GratwurstEnabled: " .. tostring(GratwurstEnabled))
-		print("GratwurstVariancePercentage: " .. GratwurstVariancePercentage)
 		print("GratwurstIsGratzing: " .. tostring(GratwurstIsGratzing))
+		print("GratwurstRandomDelayMax: " .. GratwurstRandomDelayMax)
+		print("GratwurstDelayInSeconds: " .. GratwurstDelayInSeconds)
+		print("GratwurstVariancePercentage: " .. GratwurstVariancePercentage)
+		print("GratwurstShouldRandomize: " .. tostring(GratwurstShouldRandomize))
+		print("GratwurstMessages count: " .. #GratwurstMessages)
 		GuildAchievementMessageEventReceived(true);
 	end
 end


### PR DESCRIPTION
Adds GratwurstShouldRandomize and GratwurstMessages count to the debug printout, reorders fields to surface the IsGratzing lock prominently, and lists /gw debug in the help text so it's discoverable. Useful for verifying the IsGratzing bug fix.